### PR TITLE
Add repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "watch": "babel -w src --out-dir . --ignore __tests__",
     "prepublish": "cross-env NODE_ENV=production npm run build"
   },
+  "repository": "github:dmiepub/gatsby-source-api",
   "version": "0.0.2",
   "devDependencies": {
     "cross-env": "^5.0.5"


### PR DESCRIPTION
Hi @dmiepub :wave: Adding this field will link to GitHub from npm and Gatsby:

- https://www.npmjs.com/package/gatsby-source-api
- https://www.gatsbyjs.org/packages/gatsby-source-api/?=api